### PR TITLE
Fixed title on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Rooms 2.0
+# SSB Specifications by the NGI Pointer group
+
+## Rooms 2.0
 
 - [Rooms 2.0 specification](https://ssb-ngi-pointer.github.io/rooms2)
 - [SSB URIs specification](https://github.com/ssb-ngi-pointer/ssb-uri-spec)
 - [SSB HTTP Invites specification](https://ssb-ngi-pointer.github.io/ssb-http-invite-spec)
 - [SSB HTTP Authentication specification](https://ssb-ngi-pointer.github.io/ssb-http-auth-spec)
 
-# Meta feeds
+## Meta feeds
 
 - [Meta feeds specification](https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec)
 - [Using meta feeds for partial replication](https://github.com/ssb-ngi-pointer/ssb-secure-partial-replication-spec)


### PR DESCRIPTION
Currently, the title defaults to the first `<h1>` in the README text. That means that it is using _Rooms 2.0_ as the title for the page which is misleading since it covers more than just rooms 2.0. This patch changes it to be more descriptive of its content.